### PR TITLE
Add admin user password reset support

### DIFF
--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -271,9 +271,9 @@ class CognitoClient
      *
      * @see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserPassword.html
      *
-     * @param  string  $username
-     * @param  string  $password
-     * @param  boolean $permanent
+     * @param  string $username
+     * @param  string $password
+     * @param  bool $permanent
      * @return bool
      */
     public function setUserPassword($username, $password, $permanent = true)

--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -266,6 +266,40 @@ class CognitoClient
         }
     }
 
+    /**
+     * Sets the specified user's password in a user pool as an administrator.
+     *
+     * @see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserPassword.html
+     *
+     * @param  string  $username
+     * @param  string  $password
+     * @param  boolean $permanent
+     * @return bool
+     */
+    public function setUserPassword($username, $password, $permanent = true)
+    {
+        try {
+            $this->client->adminSetUserPassword([
+                'Password'   => $password,
+                'Permanent'  => $permanent,
+                'Username'   => $username,
+                'UserPoolId' => $this->poolId,
+            ]);
+        } catch (CognitoIdentityProviderException $e) {
+            if ($e->getAwsErrorCode() === self::USER_NOT_FOUND) {
+                return Password::INVALID_USER;
+            }
+
+            if ($e->getAwsErrorCode() === self::INVALID_PASSWORD) {
+                return Password::INVALID_PASSWORD;
+            }
+
+            throw $e;
+        }
+
+        return Password::PASSWORD_RESET;
+    }
+    
     public function invalidatePassword($username)
     {
         $this->client->adminResetUserPassword([

--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -299,7 +299,7 @@ class CognitoClient
 
         return Password::PASSWORD_RESET;
     }
-    
+
     public function invalidatePassword($username)
     {
         $this->client->adminResetUserPassword([


### PR DESCRIPTION
In order to allow for user passwords to be changed without having to go through the usual password reset procedure which in turn requires a code, this allows for the password to be reset manually by via `adminSetUserPassword` (docs below).

https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminSetUserPassword.html
