### PR TITLE
Update Auth Flow name to match AWS Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ If you are already working on an existing project and want to integrate Cognito 
 
 ## Usage
 
-Our package is providing you 4 traits you can just add to your Auth Controllers to get our package running.
+Our package is providing you 5 traits you can just add to your Auth Controllers to get our package running.
 
 - BlackBits\LaravelCognitoAuth\Auth\AuthenticatesUsers
 - BlackBits\LaravelCognitoAuth\Auth\RegistersUsers
 - BlackBits\LaravelCognitoAuth\Auth\ResetsPasswords
 - BlackBits\LaravelCognitoAuth\Auth\SendsPasswordResetEmails
+- BlackBits\LaravelCognitoAuth\Auth\VerifiesEmails
 
 
 In the simplest way you just go through your Auth Controllers and change namespaces from the traits which are currently implemented from Laravel.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Next, generate an App Client. This will give you the App client id and the App c
 you need for your `.env` file. 
 
 *IMPORTANT: Don't forget to activate the checkbox to Enable sign-in API for server-based Authentication. 
-The Auth Flow is called: ADMIN_NO_SRP_AUTH*
+The Auth Flow is called: ADMIN_USER_PASSWORD_AUTH (formerly ADMIN_NO_SRP_AUTH)*
 
 You also need a new IAM Role with the following Access Rights:
 


### PR DESCRIPTION
Hi guys, thanks for writing this library!

I found that the documentation needs updating.

Per the official AWS docs, they've renamed the name of the Auth Flow for server-based authentication: https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html#amazon-cognito-user-pools-server-side-authentication-flow

> Pass ADMIN_USER_PASSWORD_AUTH (formerly known as ADMIN_NO_SRP_AUTH) for the ExplicitAuthFlow parameter in your server-side app's call to CreateUserPoolClient or UpdateUserPoolClient.
> Choose Enable sign-in API for server-based authentication (ADMIN_USER_PASSWORD_AUTH) in the App clients tab in Create a user pool. For more information, see Configuring a User Pool App Client.

This confused me for a long time, trying to get this implemented--I figured this will help the next person who comes along.