### PR TITLE
Laravel 6 Compatibility - removes reference to Password::INVALID_PASSWORD const

### DIFF
--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -2,6 +2,7 @@
 
 namespace BlackBits\LaravelCognitoAuth;
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Password;
 use Aws\CognitoIdentityProvider\CognitoIdentityProviderClient;
 use Aws\CognitoIdentityProvider\Exception\CognitoIdentityProviderException;
@@ -172,7 +173,7 @@ class CognitoClient
             }
 
             if ($e->getAwsErrorCode() === self::INVALID_PASSWORD) {
-                return 'passwords.password';
+                return Lang::has('passwords.password') ? 'passwords.password' : $e->getAwsErrorMessage();
             }
 
             if ($e->getAwsErrorCode() === self::CODE_MISMATCH || $e->getAwsErrorCode() === self::EXPIRED_CODE) {
@@ -292,7 +293,7 @@ class CognitoClient
             }
 
             if ($e->getAwsErrorCode() === self::INVALID_PASSWORD) {
-                return 'passwords.password';
+                return Lang::has('passwords.password') ? 'passwords.password' : $e->getAwsErrorMessage();
             }
 
             throw $e;

--- a/src/CognitoClient.php
+++ b/src/CognitoClient.php
@@ -172,7 +172,7 @@ class CognitoClient
             }
 
             if ($e->getAwsErrorCode() === self::INVALID_PASSWORD) {
-                return Password::INVALID_PASSWORD;
+                return 'passwords.password';
             }
 
             if ($e->getAwsErrorCode() === self::CODE_MISMATCH || $e->getAwsErrorCode() === self::EXPIRED_CODE) {
@@ -292,7 +292,7 @@ class CognitoClient
             }
 
             if ($e->getAwsErrorCode() === self::INVALID_PASSWORD) {
-                return Password::INVALID_PASSWORD;
+                return 'passwords.password';
             }
 
             throw $e;


### PR DESCRIPTION
The INVALID_PASSWORD const has been removed from Laravel since version 6:
https://github.com/laravel/framework/commit/b3e69f1122d1234ccc961a6dad279ddcbbf97b47
https://github.com/laravel/framework/commit/88ec20dbaac61453f1f48e4013af3b3d96ad0729
https://github.com/laravel/laravel/commit/4852f483466bdc83bac132421832d3eec07bcfaf

I've opted to replace it with the default translation key (passwords.password), falling back to the AWS Error Message if no translation exists (as is the case with new L6/7 projects).

This should have no effect on existing projects using Laravel 5.x, whilst remaining compatible with current versions of Laravel.

EDIT: I realise that in other areas of the CognitoClient class, translation paths are specified with no fallback to the exception error message. If you would prefer to keep consistent with that, I can revert the second commit. 