### PR TITLE
Conditionally pass credentials so that CredentialProvider is used as a fallback

### DIFF
--- a/src/CognitoAuthServiceProvider.php
+++ b/src/CognitoAuthServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace BlackBits\LaravelCognitoAuth;
 
+use Illuminate\Support\Arr;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use BlackBits\LaravelCognitoAuth\Auth\CognitoGuard;

--- a/src/CognitoAuthServiceProvider.php
+++ b/src/CognitoAuthServiceProvider.php
@@ -25,10 +25,15 @@ class CognitoAuthServiceProvider extends ServiceProvider
 
         $this->app->singleton(CognitoClient::class, function (Application $app) {
             $config = [
-                'credentials' => config('cognito.credentials'),
                 'region'      => config('cognito.region'),
                 'version'     => config('cognito.version'),
             ];
+
+            $credentials = config('cognito.credentials');
+
+            if (! empty($credentials['key']) && ! empty($credentials['secret'])) {
+                $config['credentials'] = Arr::only($credentials, ['key', 'secret', 'token']);
+            }
 
             return new CognitoClient(
                 new CognitoIdentityProviderClient($config),


### PR DESCRIPTION
Motivation: I use instance profile credentials for all of my Laravel -> AWS stuff. Currently, it's not possible to do that using this package, as it passes the key/secret credentials no matter what (even if blank)

Following the same convention as the Laravel Filesystem Manager, I've opted to conditionally append credentials to the config passed to the Cognito Client.
https://github.com/illuminate/filesystem/blob/master/FilesystemManager.php#L222-L231

The AWS SDK is kinda hard to follow here, but basically:
- The Cognito Api Client is created
- arguments are passed, resolved, validated through some big map: https://github.com/aws/aws-sdk-php/blob/master/src/ClientResolver.php#L277-L297
- the map item we're interested in is the credentials:
https://github.com/aws/aws-sdk-php/blob/master/src/ClientResolver.php#L139-L145
- basically, if `! isset($config['credentials'])`, the CredentialProvider is used: https://github.com/aws/aws-sdk-php/blob/master/src/ClientResolver.php#L464-L467
- this credential provider attempts a bunch of methods to get valid credentials, including instance profile credentials