### PR TITLE
Using an unregistered email in the Reset Password from leads to ErrorException

### DIFF
--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -25,7 +25,8 @@ trait ResetsPasswords
 
         $user = $client->getUser($request->email);
 
-        if ($user['UserStatus'] == CognitoClient::FORCE_PASSWORD_STATUS) {
+        if (isset($user['UserStatus'])
+            && $user['UserStatus'] == CognitoClient::FORCE_PASSWORD_STATUS) {
             $response = $this->forceNewPassword($request);
         } else {
             $response = $client->resetPassword($request->token, $request->email, $request->password);


### PR DESCRIPTION
Using an unregistered email in the Reset Password from leads to ErrorException

steps to reproduce:

1. Go to Reset Password form (/password-reset)
2. Fill Email Address field with a valid but unregistered email
3. Fill the rest of the form correctly
4. Submit Reset Password form

Result: 

> ErrorException
> Trying to access array offset on value of type bool 

> Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
> vendor/black-bits/laravel-cognito-auth/src/Auth/ResetsPasswords.php:28


```
if ($user['UserStatus'] == CognitoClient::FORCE_PASSWORD_STATUS) {
```

the solution in this commit was tested and it works as expected